### PR TITLE
docs: Fix a few typos

### DIFF
--- a/baseboard/kukui/charger_mt6370.c
+++ b/baseboard/kukui/charger_mt6370.c
@@ -170,7 +170,7 @@ int command_jc(int argc, char **argv)
 DECLARE_CONSOLE_COMMAND(jc, command_jc, "", "mt6370 junction temp");
 
 /*
- * b/143318064: A workwround for mt6370 bad buck efficiency.
+ * b/143318064: A workaround for mt6370 bad buck efficiency.
  * If the delta of VBUS and VBAT(on krane, desired voltage 4.4V) is too small
  * (i.e. < 500mV), the buck throughput will be bounded, and causing that we
  * can't drain 5V/3A when battery SoC above around 40%.

--- a/board/hatch/board.c
+++ b/board/hatch/board.c
@@ -230,7 +230,7 @@ static const mat33_fp_t base_standard_ref = {
 /*
  * TODO(b/124337208): P0 boards don't have this sensor mounted so the rotation
  * matrix can't be tested properly. This needs to be revisited after EVT to make
- * sure the rotaiton matrix for the lid sensor is correct.
+ * sure the rotation matrix for the lid sensor is correct.
  */
 static const mat33_fp_t lid_standard_ref = {
 	{ 0, FLOAT_TO_FP(-1), 0},

--- a/board/stryke/board.c
+++ b/board/stryke/board.c
@@ -191,7 +191,7 @@ static const mat33_fp_t base_standard_ref = {
 /*
  * TODO(b/124337208): P0 boards don't have this sensor mounted so the rotation
  * matrix can't be tested properly. This needs to be revisited after EVT to make
- * sure the rotaiton matrix for the lid sensor is correct.
+ * sure the rotation matrix for the lid sensor is correct.
  */
 static const mat33_fp_t lid_standard_ref = {
 	{ 0, FLOAT_TO_FP(-1), 0},

--- a/chip/npcx/system-npcx5.c
+++ b/chip/npcx/system-npcx5.c
@@ -205,7 +205,7 @@ void system_download_from_flash(uint32_t srcAddr, uint32_t dstAddr,
 	ASSERT((size % chunkSize) == 0 && (srcAddr % chunkSize) == 0 &&
 			(dstAddr % chunkSize) == 0);
 
-	/* Check valid address for jumpiing */
+	/* Check valid address for jumping */
 	ASSERT(exeAddr != 0x0);
 
 	/* Enable power for the Low Power RAM */

--- a/chip/npcx/system-npcx7.c
+++ b/chip/npcx/system-npcx7.c
@@ -335,7 +335,7 @@ void system_download_from_flash(uint32_t srcAddr, uint32_t dstAddr,
 	ASSERT((size % chunkSize) == 0 && (srcAddr % chunkSize) == 0 &&
 			(dstAddr % chunkSize) == 0);
 
-	/* Check valid address for jumpiing */
+	/* Check valid address for jumping */
 	ASSERT(exeAddr != 0x0);
 
 	/* Enable power for the Low Power RAM */

--- a/driver/bc12/pi3usb9201.c
+++ b/driver/bc12/pi3usb9201.c
@@ -203,7 +203,7 @@ static void bc12_power_down(int port)
 	pi3usb9201_set_mode(port, PI3USB9201_POWER_DOWN);
 	/* The start bc1.2 bit does not auto clear */
 	pi3usb9201_bc12_detect_ctrl(port, 0);
-	/* Mask interrupts unitl next bc1.2 detection event */
+	/* Mask interrupts until next bc1.2 detection event */
 	pi3usb9201_interrupt_mask(port, 1);
 	/*
 	 * Let charge manager know there's no more charge available for the

--- a/driver/charger/rt946x.h
+++ b/driver/charger/rt946x.h
@@ -737,7 +737,7 @@ int rt946x_is_charge_done(void);
  */
 int rt946x_cutoff_battery(void);
 
-/* Enable/Disable charge temination */
+/* Enable/Disable charge termination */
 int rt946x_enable_charge_termination(int en);
 
 /* Enable/Disable charge EOC */


### PR DESCRIPTION
There are small typos in:
- baseboard/kukui/charger_mt6370.c
- board/hatch/board.c
- board/stryke/board.c
- chip/npcx/system-npcx5.c
- chip/npcx/system-npcx7.c
- driver/bc12/pi3usb9201.c
- driver/charger/rt946x.h

Fixes:
- Should read `jumping` rather than `jumpiing`.
- Should read `rotation` rather than `rotaiton`.
- Should read `workaround` rather than `workwround`.
- Should read `until` rather than `unitl`.
- Should read `termination` rather than `temination`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md