### PR TITLE
Send Fn scancode to OS on press and release

### DIFF
--- a/board/hx20/keyboard_customization.c
+++ b/board/hx20/keyboard_customization.c
@@ -488,12 +488,17 @@ enum ec_error_list keyboard_scancode_callback(uint16_t *make_code,
 	if (factory_status())
 		return EC_SUCCESS;
 
-	if (pressed_key == SCANCODE_FN && pressed) {
-		Fn_key |= FN_PRESSED;
-		return EC_ERROR_UNIMPLEMENTED;
-	} else if (pressed_key == SCANCODE_FN && !pressed) {
-		Fn_key &= ~FN_PRESSED;
-		return EC_ERROR_UNIMPLEMENTED;
+	/*
+	 * Record Fn button press in the Fn_key mask and return
+	 * scancode to OS
+	 */
+	if (pressed_key == SCANCODE_FN) {
+		if (pressed) {
+			Fn_key |= FN_PRESSED;
+		} else {
+			Fn_key &= ~FN_PRESSED;
+		}
+		return EC_SUCCESS;
 	}
 
 	/*


### PR DESCRIPTION
Proposed change implements return of EC_SUCCESS from keyboard_scancode_callback on press and release of Fn key. This is needed in order to send the the scancode to OS.
This is primarily quality of life change since it would allow the OS to bind Fn key to some other modifier. Similar functionality exists on macOS for Apple Macbooks. From personal experience I've found  remapping of Fn to Ctrl extremely useful, as it allows my muscle memory to work similarly on both Framework and Macbook laptops.
I am not convinced that his commit is enough tho, since the Fn hotkeys are technically sending completely different scancoded for actions (think of Home/End/PgDown/PgUp). OS might recognize those as used while the bound modifier is pressed. The obvious solution would be to send three scancodes in a row: release Fn, hotkey scancode, press Fn. I would expect EC firmware implement this on its own, but have not verified that yet. 
Feedback is very welcome