### PR TITLE
cypress5525: Correct a compiler warning

### DIFF
--- a/board/hx30/cypress5525.c
+++ b/board/hx30/cypress5525.c
@@ -977,7 +977,7 @@ void cyp5525_port_int(int controller, int port)
 		port,
 		data2[0],
 		data2[1]);
-    }
+	}
 
 	response_len = data2[1];
 	switch (data2[0]) {

--- a/board/hx30/cypress5525.c
+++ b/board/hx30/cypress5525.c
@@ -971,12 +971,13 @@ void cyp5525_port_int(int controller, int port)
 	int port_idx = (controller << 1) + port;
 	/* enum pd_msg_type sop_type; */
 	rv = i2c_read_offset16_block(i2c_port, addr_flags, CYP5525_PORT_PD_RESPONSE_REG(port), data2, 4);
-	if (rv != EC_SUCCESS)
+	if (rv != EC_SUCCESS) {
 		CPRINTS("PORT_PD_RESPONSE_REG failed");
 		print_pd_response_code(controller,
 		port,
 		data2[0],
 		data2[1]);
+    }
 
 	response_len = data2[1];
 	switch (data2[0]) {

--- a/board/hx30/cypress5525.c
+++ b/board/hx30/cypress5525.c
@@ -971,13 +971,13 @@ void cyp5525_port_int(int controller, int port)
 	int port_idx = (controller << 1) + port;
 	/* enum pd_msg_type sop_type; */
 	rv = i2c_read_offset16_block(i2c_port, addr_flags, CYP5525_PORT_PD_RESPONSE_REG(port), data2, 4);
-	if (rv != EC_SUCCESS) {
+	if (rv != EC_SUCCESS)
 		CPRINTS("PORT_PD_RESPONSE_REG failed");
-		print_pd_response_code(controller,
+
+	print_pd_response_code(controller,
 		port,
 		data2[0],
 		data2[1]);
-	}
 
 	response_len = data2[1];
 	switch (data2[0]) {


### PR DESCRIPTION
This seems to be handling an error case incorrectly.

board/hx30/cypress5525.c: In function 'cyp5525_port_int': board/hx30/cypress5525.c:974:9: error: this 'if' clause does not guard...
   [-Werror=misleading-indentation]
  974 |         if (rv != EC_SUCCESS)
      |         ^~
board/hx30/cypress5525.c:976:17: note: ...this statement, but the latter
   is misleadingly indented as if it were guarded by the 'if'
  976 |                 print_pd_response_code(controller,
      |                 ^~~~~~~~~~~~~~~~~~~~~~

Signed-off-by: Simon Glass <sjg@chromium.org>