### PR TITLE
Replicate the GCC error fix from the hx30 to hx20

### DIFF
--- a/board/hx20/cypress5525.c
+++ b/board/hx20/cypress5525.c
@@ -968,12 +968,13 @@ void cyp5525_port_int(int controller, int port)
 	int port_idx = (controller << 1) + port;
 	enum pd_msg_type sop_type;
 	rv = i2c_read_offset16_block(i2c_port, addr_flags, CYP5525_PORT_PD_RESPONSE_REG(port), data2, 4);
-	if (rv != EC_SUCCESS)
+	if (rv != EC_SUCCESS) {
 		CPRINTS("PORT_PD_RESPONSE_REG failed");
-	print_pd_response_code(controller,
+		print_pd_response_code(controller,
 		port,
 		data2[0],
 		data2[1]);
+	}
 
 	response_len = data2[1];
 	switch (data2[0]) {


### PR DESCRIPTION
Applies the Fix from #24 into the hx20 board.