### PR TITLE
usb_pd: Remove const modifier on a function return type

### DIFF
--- a/include/usb_pd.h
+++ b/include/usb_pd.h
@@ -2702,7 +2702,7 @@ bool pd_capable(int port);
  *
  * @param port USB-C port number
  */
-const uint32_t * const pd_get_src_caps(int port);
+const uint32_t *pd_get_src_caps(int port);
 
 /**
  * Returns the number of source caps


### PR DESCRIPTION
A 'const' modifier on a function return type is useless and should be removed for clarity.