### PR TITLE
lotus: lower threshold for Apple 96W and TS4 98W chargers

### DIFF
--- a/zephyr/program/lotus/lotus/src/cpu_power.c
+++ b/zephyr/program/lotus/lotus/src/cpu_power.c
@@ -201,7 +201,7 @@ static void update_thermal_power_limit(int battery_percent, int active_mpower,
 					thermal_stt_table = 28;
 				}
 			}
-		} else if (active_mpower >= 100000) {
+		} else if (active_mpower >= 96000) {
 			if (with_dc) {
 				if (mode == EC_AC_BEST_PERFORMANCE) {
 					power_limit[FUNCTION_THERMAL_PMF].mwatt[TYPE_SPL] = 85000;
@@ -235,7 +235,7 @@ static void update_thermal_power_limit(int battery_percent, int active_mpower,
 					thermal_stt_table = 30;
 				}
 			}
-		} else if ((active_mpower < 100000) && (active_mpower > 0)) {
+		} else if ((active_mpower < 96000) && (active_mpower > 0)) {
 			if (with_dc) {
 				power_limit[FUNCTION_THERMAL_PMF].mwatt[TYPE_SPL] = 60000;
 				power_limit[FUNCTION_THERMAL_PMF].mwatt[TYPE_SPPT] = 60000;
@@ -274,7 +274,7 @@ static void update_thermal_power_limit(int battery_percent, int active_mpower,
 				power_limit[FUNCTION_SLIDER].mwatt[TYPE_FPPT];
 			power_limit[FUNCTION_THERMAL_PMF].mwatt[TYPE_APU_ONLY_SPPT] = 0;
 			thermal_stt_table = slider_stt_table;
-		} else if (active_mpower >= 100000) {
+		} else if (active_mpower >= 96000) {
 			if (mode == EC_AC_BEST_PERFORMANCE) {
 				power_limit[FUNCTION_THERMAL_PMF].mwatt[TYPE_SPL] = 45000;
 				power_limit[FUNCTION_THERMAL_PMF].mwatt[TYPE_SPPT] = 54000;


### PR DESCRIPTION
This pull request lowers the required AC charger power to get the higher SoC power limits on chargers that are almost 100W.

I and most likely a decent chunk of Framework 16 users use a Caldigit TS4 dock which unfortunately does not provide the full 100W required to get the higher power limits, but instead exposes itself as a 20V 4.9A charger (98W) as can be seen from the output of `ectool`:
> [434.789900 CL: p3 s0 i4900 v20000]

I have initially wanted to drop this limit down to 98W, but there are other chargers like the Apple 96W USB-C charger and it would also benefit the users of those to drop this threshold down to 96W so that performance is not limited while plugged into these near 100W chargers.

I have already tested this change on my non-dGPU FW16 and it has been working flawlessly.