### PR TITLE
Map fn+left win key combination to right win

### DIFF
--- a/board/hx20/keyboard_customization.c
+++ b/board/hx20/keyboard_customization.c
@@ -384,6 +384,10 @@ int hotkey_special_key(uint16_t *key_code, int8_t pressed)
 		/*if (!fn_table_set(pressed, KB_FN_S))*/
 
 		break;
+	case SCANCODE_LEFT_WIN:  /* RIGHT WIN */
+		if (fn_table_set(pressed, KB_FN_LEFT_WIN))
+			*key_code = SCANCODE_RIGHT_WIN;
+		break;
 	case SCANCODE_LEFT:  /* HOME */
 		if (fn_table_set(pressed, KB_FN_LEFT))
 			*key_code = 0xe06c;

--- a/board/hx20/keyboard_customization.h
+++ b/board/hx20/keyboard_customization.h
@@ -96,6 +96,7 @@ enum kb_fn_table {
 	KB_FN_B = BIT(20),
 	KB_FN_P = BIT(21),
 	KB_FN_SPACE = BIT(22),
+	KB_FN_LEFT_WIN = BIT(24),
 };
 
 #ifdef CONFIG_KEYBOARD_BACKLIGHT

--- a/board/hx30/keyboard_customization.c
+++ b/board/hx30/keyboard_customization.c
@@ -384,6 +384,10 @@ int hotkey_special_key(uint16_t *key_code, int8_t pressed)
 		/*if (!fn_table_set(pressed, KB_FN_S))*/
 
 		break;
+	case SCANCODE_LEFT_WIN:  /* RIGHT WIN */
+		if (fn_table_set(pressed, KB_FN_LEFT_WIN))
+			*key_code = SCANCODE_RIGHT_WIN;
+		break;
 	case SCANCODE_LEFT:  /* HOME */
 		if (fn_table_set(pressed, KB_FN_LEFT))
 			*key_code = 0xe06c;

--- a/board/hx30/keyboard_customization.h
+++ b/board/hx30/keyboard_customization.h
@@ -96,6 +96,7 @@ enum kb_fn_table {
     KB_FN_B = BIT(20),
     KB_FN_P = BIT(21),
     KB_FN_SPACE = BIT(22),
+	KB_FN_LEFT_WIN = BIT(24),
 };
 
 #ifdef CONFIG_KEYBOARD_BACKLIGHT


### PR DESCRIPTION
Allows users to customize the behavior of fn+win by remapping right win in the OS.