### PR TITLE
Add fn key combinations to emit international keyboard keys

### DIFF
--- a/board/hx20/keyboard_customization.c
+++ b/board/hx20/keyboard_customization.c
@@ -376,6 +376,10 @@ int hotkey_special_key(uint16_t *key_code, int8_t pressed)
 		if (fn_table_set(pressed, KB_FN_DELETE))
 			*key_code = 0xe070;
 		break;
+	case 0x0055:  /* = -> YEN */
+		if (fn_table_set(pressed, KB_FN_EQUALS))
+			*key_code = 0x006A;
+		break;
 	case SCANCODE_K:  /* TODO: SCROLL_LOCK */
 		if (fn_table_set(pressed, KB_FN_K))
 			*key_code = SCANCODE_SCROLL_LOCK;

--- a/board/hx20/keyboard_customization.c
+++ b/board/hx20/keyboard_customization.c
@@ -384,6 +384,14 @@ int hotkey_special_key(uint16_t *key_code, int8_t pressed)
 		/*if (!fn_table_set(pressed, KB_FN_S))*/
 
 		break;
+	case 0x001A:  /* Z -> 102ND */
+		if (fn_table_set(pressed, KB_FN_Z))
+			*key_code = 0x0061;
+		break;
+	case 0x004A:  /* ? -> RO KANA */
+		if (fn_table_set(pressed, KB_FN_QUESTIONMARK))
+			*key_code = 0x0051;
+		break;
 	case SCANCODE_LEFT:  /* HOME */
 		if (fn_table_set(pressed, KB_FN_LEFT))
 			*key_code = 0xe06c;

--- a/board/hx20/keyboard_customization.c
+++ b/board/hx20/keyboard_customization.c
@@ -392,6 +392,18 @@ int hotkey_special_key(uint16_t *key_code, int8_t pressed)
 		if (fn_table_set(pressed, KB_FN_Z))
 			*key_code = 0x0061;
 		break;
+	case 0x0021:  /* C -> MUHENKAN */
+		if (fn_table_set(pressed, KB_FN_C))
+			*key_code = 0x0067;
+		break;
+	case 0x003A:  /* M -> HENKAN */
+		if (fn_table_set(pressed, KB_FN_M))
+			*key_code = 0x0064;
+		break;
+	case 0x0041:  /* , -> KATAKANA HIRAGANA */
+		if (fn_table_set(pressed, KB_FN_COMMA))
+			*key_code = 0x0013;
+		break;
 	case 0x004A:  /* ? -> RO KANA */
 		if (fn_table_set(pressed, KB_FN_QUESTIONMARK))
 			*key_code = 0x0051;

--- a/board/hx20/keyboard_customization.h
+++ b/board/hx20/keyboard_customization.h
@@ -96,6 +96,8 @@ enum kb_fn_table {
 	KB_FN_B = BIT(20),
 	KB_FN_P = BIT(21),
 	KB_FN_SPACE = BIT(22),
+	KB_FN_Z = BIT(25),
+	KB_FN_QUESTIONMARK = BIT(26),
 };
 
 #ifdef CONFIG_KEYBOARD_BACKLIGHT

--- a/board/hx20/keyboard_customization.h
+++ b/board/hx20/keyboard_customization.h
@@ -98,6 +98,7 @@ enum kb_fn_table {
 	KB_FN_SPACE = BIT(22),
 	KB_FN_Z = BIT(25),
 	KB_FN_QUESTIONMARK = BIT(26),
+	KB_FN_EQUALS = BIT(27),
 };
 
 #ifdef CONFIG_KEYBOARD_BACKLIGHT

--- a/board/hx20/keyboard_customization.h
+++ b/board/hx20/keyboard_customization.h
@@ -99,6 +99,9 @@ enum kb_fn_table {
 	KB_FN_Z = BIT(25),
 	KB_FN_QUESTIONMARK = BIT(26),
 	KB_FN_EQUALS = BIT(27),
+	KB_FN_C = BIT(28),
+	KB_FN_M = BIT(29),
+	KB_FN_COMMA = BIT(30),
 };
 
 #ifdef CONFIG_KEYBOARD_BACKLIGHT

--- a/board/hx30/keyboard_customization.c
+++ b/board/hx30/keyboard_customization.c
@@ -376,6 +376,10 @@ int hotkey_special_key(uint16_t *key_code, int8_t pressed)
 		if (fn_table_set(pressed, KB_FN_DELETE))
 			*key_code = 0xe070;
 		break;
+	case 0x0055:  /* = -> YEN */
+		if (fn_table_set(pressed, KB_FN_EQUALS))
+			*key_code = 0x006A;
+		break;
 	case SCANCODE_K:  /* TODO: SCROLL_LOCK */
 		if (fn_table_set(pressed, KB_FN_K))
 			*key_code = SCANCODE_SCROLL_LOCK;

--- a/board/hx30/keyboard_customization.c
+++ b/board/hx30/keyboard_customization.c
@@ -384,6 +384,14 @@ int hotkey_special_key(uint16_t *key_code, int8_t pressed)
 		/*if (!fn_table_set(pressed, KB_FN_S))*/
 
 		break;
+	case 0x001A:  /* Z -> 102ND */
+		if (fn_table_set(pressed, KB_FN_Z))
+			*key_code = 0x0061;
+		break;
+	case 0x004A:  /* ? -> RO KANA */
+		if (fn_table_set(pressed, KB_FN_QUESTIONMARK))
+			*key_code = 0x0051;
+		break;
 	case SCANCODE_LEFT:  /* HOME */
 		if (fn_table_set(pressed, KB_FN_LEFT))
 			*key_code = 0xe06c;

--- a/board/hx30/keyboard_customization.c
+++ b/board/hx30/keyboard_customization.c
@@ -392,6 +392,18 @@ int hotkey_special_key(uint16_t *key_code, int8_t pressed)
 		if (fn_table_set(pressed, KB_FN_Z))
 			*key_code = 0x0061;
 		break;
+	case 0x0021:  /* C -> MUHENKAN */
+		if (fn_table_set(pressed, KB_FN_C))
+			*key_code = 0x0067;
+		break;
+	case 0x003A:  /* M -> HENKAN */
+		if (fn_table_set(pressed, KB_FN_M))
+			*key_code = 0x0064;
+		break;
+	case 0x0041:  /* , -> KATAKANA HIRAGANA */
+		if (fn_table_set(pressed, KB_FN_COMMA))
+			*key_code = 0x0013;
+		break;
 	case 0x004A:  /* ? -> RO KANA */
 		if (fn_table_set(pressed, KB_FN_QUESTIONMARK))
 			*key_code = 0x0051;

--- a/board/hx30/keyboard_customization.h
+++ b/board/hx30/keyboard_customization.h
@@ -96,6 +96,8 @@ enum kb_fn_table {
     KB_FN_B = BIT(20),
     KB_FN_P = BIT(21),
     KB_FN_SPACE = BIT(22),
+	KB_FN_Z = BIT(25),
+	KB_FN_QUESTIONMARK = BIT(26),
 };
 
 #ifdef CONFIG_KEYBOARD_BACKLIGHT

--- a/board/hx30/keyboard_customization.h
+++ b/board/hx30/keyboard_customization.h
@@ -99,6 +99,9 @@ enum kb_fn_table {
 	KB_FN_Z = BIT(25),
 	KB_FN_QUESTIONMARK = BIT(26),
 	KB_FN_EQUALS = BIT(27),
+	KB_FN_C = BIT(28),
+	KB_FN_M = BIT(29),
+	KB_FN_COMMA = BIT(30),
 };
 
 #ifdef CONFIG_KEYBOARD_BACKLIGHT

--- a/board/hx30/keyboard_customization.h
+++ b/board/hx30/keyboard_customization.h
@@ -98,6 +98,7 @@ enum kb_fn_table {
     KB_FN_SPACE = BIT(22),
 	KB_FN_Z = BIT(25),
 	KB_FN_QUESTIONMARK = BIT(26),
+	KB_FN_EQUALS = BIT(27),
 };
 
 #ifdef CONFIG_KEYBOARD_BACKLIGHT


### PR DESCRIPTION
Maps fn+Z to the ISO 102nd key, fn+/ to the extra key left of right shift on Brazilian and Japanese layouts, and fn+= to the JIS Yen key. This allows full use of ISO and Brazilian layouts on ANSI, ISO, or JIS keyboard hardware. (Alternately, users can remap these keys in the OS to whatever function they prefer.)