### PR TITLE
Add fn key mappings for number row

### DIFF
--- a/board/hx20/keyboard_customization.c
+++ b/board/hx20/keyboard_customization.c
@@ -376,6 +376,58 @@ int hotkey_special_key(uint16_t *key_code, int8_t pressed)
 		if (fn_table_set(pressed, KB_FN_DELETE))
 			*key_code = 0xe070;
 		break;
+	case 0x000E:  /* ` -> F13 */
+		if (fn_table_set(pressed, KB_FN_GRAVE))
+			*key_code = 0x0008;
+		break;
+	case 0x0016:  /* 1 -> F14 */
+		if (fn_table_set(pressed, KB_FN_1))
+			*key_code = 0x0010;
+		break;
+	case 0x001E:  /* 2 -> F15 */
+		if (fn_table_set(pressed, KB_FN_2))
+			*key_code = 0x0018;
+		break;
+	case 0x0026:  /* 3 -> F16 */
+		if (fn_table_set(pressed, KB_FN_3))
+			*key_code = 0x0020;
+		break;
+	case 0x0025:  /* 4 -> F17 */
+		if (fn_table_set(pressed, KB_FN_4))
+			*key_code = 0x0028;
+		break;
+	case 0x002E:  /* 5 -> F18 */
+		if (fn_table_set(pressed, KB_FN_5))
+			*key_code = 0x0030;
+		break;
+	case 0x0036:  /* 6 -> F19 */
+		if (fn_table_set(pressed, KB_FN_6))
+			*key_code = 0x0038;
+		break;
+	case 0x003D:  /* 7 -> F20 */
+		if (fn_table_set(pressed, KB_FN_7))
+			*key_code = 0x0040;
+		break;
+	case 0x003E:  /* 8 -> F21 */
+		if (fn_table_set(pressed, KB_FN_8))
+			*key_code = 0x0048;
+		break;
+	case 0x0046:  /* 9 -> F22 */
+		if (fn_table_set(pressed, KB_FN_9))
+			*key_code = 0x0050;
+		break;
+	case 0x0045:  /* 0 -> F23 */
+		if (fn_table_set(pressed, KB_FN_0))
+			*key_code = 0x0057;
+		break;
+	case 0x004E:  /* - -> F24 */
+		if (fn_table_set(pressed, KB_FN_HYPHEN))
+			*key_code = 0x005F;
+		break;
+	case 0x0055:  /* = -> YEN */
+		if (fn_table_set(pressed, KB_FN_EQUALS))
+			*key_code = 0x006A;
+		break;
 	case SCANCODE_K:  /* TODO: SCROLL_LOCK */
 		if (fn_table_set(pressed, KB_FN_K))
 			*key_code = SCANCODE_SCROLL_LOCK;

--- a/board/hx20/keyboard_customization.h
+++ b/board/hx20/keyboard_customization.h
@@ -72,7 +72,7 @@ extern uint8_t keyboard_cols;
 #define KEYBOARD_ROW_LEFT_SHIFT 5
 #define KEYBOARD_MASK_LEFT_SHIFT KEYBOARD_ROW_TO_MASK(KEYBOARD_ROW_LEFT_SHIFT)
 
-enum kb_fn_table {
+enum kb_fn_table_media {
 	KB_FN_F1 = BIT(0),
 	KB_FN_F2 = BIT(1),
 	KB_FN_F3 = BIT(2),
@@ -85,6 +85,21 @@ enum kb_fn_table {
 	KB_FN_F10 = BIT(9),
 	KB_FN_F11 = BIT(10),
 	KB_FN_F12 = BIT(11),
+};
+
+enum kb_fn_table {
+	KB_FN_GRAVE = BIT(0),
+	KB_FN_1 = BIT(1),
+	KB_FN_2 = BIT(2),
+	KB_FN_3 = BIT(3),
+	KB_FN_4 =  BIT(4),
+	KB_FN_5 = BIT(5),
+	KB_FN_6 = BIT(6),
+	KB_FN_7 = BIT(7),
+	KB_FN_8 = BIT(8),
+	KB_FN_9 = BIT(9),
+	KB_FN_0 = BIT(10),
+	KB_FN_HYPHEN = BIT(11),
 	KB_FN_DELETE = BIT(12),
 	KB_FN_K = BIT(13),
 	KB_FN_S = BIT(14),
@@ -96,6 +111,7 @@ enum kb_fn_table {
 	KB_FN_B = BIT(20),
 	KB_FN_P = BIT(21),
 	KB_FN_SPACE = BIT(22),
+	KB_FN_EQUALS = BIT(27),
 };
 
 #ifdef CONFIG_KEYBOARD_BACKLIGHT

--- a/board/hx30/keyboard_customization.c
+++ b/board/hx30/keyboard_customization.c
@@ -376,6 +376,58 @@ int hotkey_special_key(uint16_t *key_code, int8_t pressed)
 		if (fn_table_set(pressed, KB_FN_DELETE))
 			*key_code = 0xe070;
 		break;
+	case 0x000E:  /* ` -> F13 */
+		if (fn_table_set(pressed, KB_FN_GRAVE))
+			*key_code = 0x0008;
+		break;
+	case 0x0016:  /* 1 -> F14 */
+		if (fn_table_set(pressed, KB_FN_1))
+			*key_code = 0x0010;
+		break;
+	case 0x001E:  /* 2 -> F15 */
+		if (fn_table_set(pressed, KB_FN_2))
+			*key_code = 0x0018;
+		break;
+	case 0x0026:  /* 3 -> F16 */
+		if (fn_table_set(pressed, KB_FN_3))
+			*key_code = 0x0020;
+		break;
+	case 0x0025:  /* 4 -> F17 */
+		if (fn_table_set(pressed, KB_FN_4))
+			*key_code = 0x0028;
+		break;
+	case 0x002E:  /* 5 -> F18 */
+		if (fn_table_set(pressed, KB_FN_5))
+			*key_code = 0x0030;
+		break;
+	case 0x0036:  /* 6 -> F19 */
+		if (fn_table_set(pressed, KB_FN_6))
+			*key_code = 0x0038;
+		break;
+	case 0x003D:  /* 7 -> F20 */
+		if (fn_table_set(pressed, KB_FN_7))
+			*key_code = 0x0040;
+		break;
+	case 0x003E:  /* 8 -> F21 */
+		if (fn_table_set(pressed, KB_FN_8))
+			*key_code = 0x0048;
+		break;
+	case 0x0046:  /* 9 -> F22 */
+		if (fn_table_set(pressed, KB_FN_9))
+			*key_code = 0x0050;
+		break;
+	case 0x0045:  /* 0 -> F23 */
+		if (fn_table_set(pressed, KB_FN_0))
+			*key_code = 0x0057;
+		break;
+	case 0x004E:  /* - -> F24 */
+		if (fn_table_set(pressed, KB_FN_HYPHEN))
+			*key_code = 0x005F;
+		break;
+	case 0x0055:  /* = -> YEN */
+		if (fn_table_set(pressed, KB_FN_EQUALS))
+			*key_code = 0x006A;
+		break;
 	case SCANCODE_K:  /* TODO: SCROLL_LOCK */
 		if (fn_table_set(pressed, KB_FN_K))
 			*key_code = SCANCODE_SCROLL_LOCK;

--- a/board/hx30/keyboard_customization.h
+++ b/board/hx30/keyboard_customization.h
@@ -72,7 +72,7 @@ extern uint8_t keyboard_cols;
 #define KEYBOARD_ROW_LEFT_SHIFT 5
 #define KEYBOARD_MASK_LEFT_SHIFT KEYBOARD_ROW_TO_MASK(KEYBOARD_ROW_LEFT_SHIFT)
 
-enum kb_fn_table {
+enum kb_fn_table_media {
 	KB_FN_F1 = BIT(0),
 	KB_FN_F2 = BIT(1),
 	KB_FN_F3 = BIT(2),
@@ -85,6 +85,21 @@ enum kb_fn_table {
 	KB_FN_F10 = BIT(9),
 	KB_FN_F11 = BIT(10),
 	KB_FN_F12 = BIT(11),
+};
+
+enum kb_fn_table {
+	KB_FN_GRAVE = BIT(0),
+	KB_FN_1 = BIT(1),
+	KB_FN_2 = BIT(2),
+	KB_FN_3 = BIT(3),
+	KB_FN_4 =  BIT(4),
+	KB_FN_5 = BIT(5),
+	KB_FN_6 = BIT(6),
+	KB_FN_7 = BIT(7),
+	KB_FN_8 = BIT(8),
+	KB_FN_9 = BIT(9),
+	KB_FN_0 = BIT(10),
+	KB_FN_HYPHEN = BIT(11),
 	KB_FN_DELETE = BIT(12),
 	KB_FN_K = BIT(13),
     KB_FN_S = BIT(14),
@@ -96,6 +111,7 @@ enum kb_fn_table {
     KB_FN_B = BIT(20),
     KB_FN_P = BIT(21),
     KB_FN_SPACE = BIT(22),
+	KB_FN_EQUALS = BIT(27),
 };
 
 #ifdef CONFIG_KEYBOARD_BACKLIGHT


### PR DESCRIPTION
Maps the left 12 keys to F13-F24, and =+ key to the Yen key found to the left of Backspace on Japanese keyboards (users can of course remap this in the OS to whatever they like).