### PR TITLE
Emit HID event when keyboard brightness changed via fn+space

### DIFF
--- a/board/hx20/i2c_hid_mediakeys.h
+++ b/board/hx20/i2c_hid_mediakeys.h
@@ -28,12 +28,13 @@ enum media_key {
     HID_KEY_DISPLAY_BRIGHTNESS_UP,
     HID_KEY_DISPLAY_BRIGHTNESS_DN,
     HID_KEY_AIRPLANE_MODE,
-
+    HID_KEY_KEYBOARD_BACKLIGHT,
     HID_KEY_MAX
 };
 /*HID_KEY_MAX cannot be > TASK_EVENT_CUSTOM_BIT*/
 BUILD_ASSERT(HID_KEY_MAX < 16);
 
 int update_hid_key(enum media_key key, bool pressed);
+void kblight_update_hid(uint8_t percent);
 
 #endif /* __CROS_EC_I2C_HID_MEDIAKEYS_H */

--- a/board/hx20/keyboard_customization.c
+++ b/board/hx20/keyboard_customization.c
@@ -470,6 +470,7 @@ int functional_hotkey(uint16_t *key_code, int8_t pressed)
 					break;
 				}
 				kblight_set(bl_brightness);
+				kblight_update_hid(bl_brightness);
 			}
 			/* we dont want to pass the space key event to the OS */
 			return EC_ERROR_UNIMPLEMENTED;

--- a/board/hx30/i2c_hid_mediakeys.h
+++ b/board/hx30/i2c_hid_mediakeys.h
@@ -81,6 +81,7 @@ enum media_key {
     HID_KEY_DISPLAY_BRIGHTNESS_UP,
     HID_KEY_DISPLAY_BRIGHTNESS_DN,
     HID_KEY_AIRPLANE_MODE,
+    HID_KEY_KEYBOARD_BACKLIGHT,
     HID_ALS_REPORT_LUX,
     HID_KEY_MAX
 };
@@ -89,5 +90,6 @@ BUILD_ASSERT(HID_KEY_MAX < 16);
 
 int update_hid_key(enum media_key key, bool pressed);
 void set_illuminance_value(uint16_t value);
+void kblight_update_hid(uint8_t percent);
 
 #endif /* __CROS_EC_I2C_HID_MEDIAKEYS_H */

--- a/board/hx30/keyboard_customization.c
+++ b/board/hx30/keyboard_customization.c
@@ -470,6 +470,7 @@ int functional_hotkey(uint16_t *key_code, int8_t pressed)
 					break;
 				}
 				kblight_set(bl_brightness);
+				kblight_update_hid(bl_brightness);
 			}
 			/* we dont want to pass the space key event to the OS */
 			return EC_ERROR_UNIMPLEMENTED;


### PR DESCRIPTION
Currently, changing the keyboard backlight brightness via fn+space does not notify the OS in any way. Therefore, OS indicators like GNOME Shell's keyboard backlight slider will show the wrong values. This PR corrects this issue by emitting a "Keyboard Backlight Set Level" HID event on fn+space. (The backlight brightness is still changed directly in firmware, so functionality in e.g. firmware menu won’t be affected.)