### PR TITLE
pwm: fix always false condition in pwm_get_bb_sleep_mask()

### DIFF
--- a/chip/mchp/pwm.c
+++ b/chip/mchp/pwm.c
@@ -101,8 +101,10 @@ static uint32_t pwm_get_bb_sleep_mask(int id)
 {
 	uint32_t bitpos = 32;
 
-	if (id >= MCHP_PWM_ID_MAX && id < MCHP_PWM_ID_MAX)
+	if (id >= MCHP_PWM_ID_MAX && 
+		id < (MCHP_PWM_ID_MAX + MCHP_BBLEN_INSTANCES))
 		bitpos = (uint32_t)pwm_slp_bitpos[id];
+
 	return (1ul << bitpos);
 }
 


### PR DESCRIPTION
Fix incorrect range check for BBLED PWM IDs.

The original condition:

    id >= MCHP_PWM_ID_MAX && id < MCHP_PWM_ID_MAX

can never be true. Updated the check to:

    id >= MCHP_PWM_ID_MAX &&
    id < (MCHP_PWM_ID_MAX + MCHP_BBLEN_INSTANCES)

This correctly validates BBLED instances and aligns with the size of pwm_slp_bitpos[].

Fixes #31