### PR TITLE
Fix some Azalea/Lotus logic not working on Controller 0

### DIFF
--- a/zephyr/program/framework/src/cypress_pd_common.c
+++ b/zephyr/program/framework/src/cypress_pd_common.c
@@ -1440,7 +1440,7 @@ static void perform_error_recovery(int controller)
 				battery_get_disconnect_state() != BATTERY_NOT_DISCONNECTED)) {
 
 				data[0] = PORT_TO_CONTROLLER_PORT(i);
-				cypd_write_reg_block(PORT_TO_CONTROLLER(i),
+				cypd_write_reg_block(controller,
 									CCG_DPM_CMD_REG,
 									data, 2);
 			}

--- a/zephyr/program/framework/src/cypress_pd_common.c
+++ b/zephyr/program/framework/src/cypress_pd_common.c
@@ -1268,7 +1268,7 @@ static void cypd_update_port_state(int controller, int port)
 
 	/*
 	 * The port can have several states active:
-	 * 1. Type C active (with no PD contract) CC resistor negociation only
+	 * 1. Type C active (with no PD contract) CC resistor negotiation only
 	 * 2. Type C active with PD contract
 	 * 3. Not active
 	 * Each of 1 and 2 can be either source or sink
@@ -1280,7 +1280,7 @@ static void cypd_update_port_state(int controller, int port)
 							type_c_current);
 	} else {
 		typec_set_input_current_limit(port_idx, 0, 0);
-		charge_manager_set_ceil(port,
+		charge_manager_set_ceil(port_idx,
 			CEIL_REQUESTOR_PD,
 			CHARGE_CEIL_NONE);
 	}


### PR DESCRIPTION
Hello,

Looking through the embedded controller code I found 2 areas where it seems to ignore any controller other than 0

1. Using `port` and not `port_idx` so it doesn't pass controller information along meaning that will always send to controller 0.
2. Only use loop variables for the port so it again won't ever get the correct controller information from the loop variables and will always be 0, but we already have controller passed in as an argument.