### PR TITLE
fix: correct typos and duplicate words in comments

### DIFF
--- a/board/hx20/peci_customization.c
+++ b/board/hx20/peci_customization.c
@@ -173,7 +173,7 @@ __override int stop_read_peci_temp(void)
 			return EC_ERROR_NOT_POWERED;
 		else {
 			/**
-			 * PECI read tempurature three times per second
+			 * PECI read temperature three times per second
 			 * dptf.c thermal.c temp_sensor.c
 			 */
 			if (++read_count > 3) {

--- a/board/hx30/peci_customization.c
+++ b/board/hx30/peci_customization.c
@@ -257,7 +257,7 @@ __override int stop_read_peci_temp(void)
 			return EC_ERROR_NOT_POWERED;
 		else {
 			/**
-			 * PECI read tempurature three times per second
+			 * PECI read temperature three times per second
 			 * dptf.c thermal.c temp_sensor.c
 			 */
 			if (++read_count > 3) {

--- a/common/lb_common.c
+++ b/common/lb_common.c
@@ -137,7 +137,7 @@ static inline uint8_t controller_read(int ctrl_num, uint8_t reg)
 }
 
 /******************************************************************************/
-/* Controller details. We have an ADP8861 and and ADP8863, but we can treat
+/* Controller details. We have an ADP8861 and ADP8863, but we can treat
  * them identically for our purposes */
 /******************************************************************************/
 

--- a/common/motion_lid.c
+++ b/common/motion_lid.c
@@ -49,7 +49,7 @@ static int lid_angle_is_reliable;
 /* Smoothed vectors to increase accurency. */
 static intv3_t smoothed_base, smoothed_lid;
 
-/* 8.7 m/s^2 is the the maximum acceleration parallel to the hinge */
+/* 8.7 m/s^2 is the maximum acceleration parallel to the hinge */
 #define SCALED_HINGE_VERTICAL_MAXIMUM  \
 	((int)((8.7f * MOTION_SCALING_FACTOR) / MOTION_ONE_G))
 

--- a/common/spi_nor.c
+++ b/common/spi_nor.c
@@ -664,7 +664,7 @@ int spi_nor_read(const struct spi_nor_device_t *spi_nor_device,
  * @param spi_nor_device The Serial NOR Flash device to use.
  * @param offset Flash offset to erase, must be aligned to the minimum physical
  *               erase size.
- * @param size Number of Bytes to erase, must be a multiple of the the minimum
+ * @param size Number of Bytes to erase, must be a multiple of the minimum
  *             physical erase size.
  * @return ec_error_list (non-zero on error and timeout).
  */

--- a/common/usb_pd_protocol.c
+++ b/common/usb_pd_protocol.c
@@ -1821,7 +1821,7 @@ static void handle_ctrl_request(int port, uint32_t head,
 			/*
 			 * Since Enter USB sets the mux state to SAFE mode,
 			 * resetting the mux state back to USB mode on
-			 * recieveing a NACK.
+			 * receiving a NACK.
 			 */
 			usb_mux_set(port, USB_PD_MUX_USB_ENABLED,
 				USB_SWITCH_CONNECT, pd[port].polarity);

--- a/common/usb_pd_protocol.c
+++ b/common/usb_pd_protocol.c
@@ -3579,7 +3579,7 @@ void pd_task(void *u)
 				 * some jitter of up to ~192ms, to prevent
 				 * multiple collisions. This delay also allows
 				 * the sink device to request power role swap
-				 * and allow the the accept message to be sent
+				 * and allow the accept message to be sent
 				 * prior to CMD_DISCOVER_IDENT being sent in the
 				 * SRC_READY state.
 				 */

--- a/common/usbc/usb_pe_drp_sm.c
+++ b/common/usbc/usb_pe_drp_sm.c
@@ -1674,7 +1674,7 @@ static void pe_update_wait_and_add_jitter_timer(int port)
 	 * some jitter of up to ~345ms, to prevent
 	 * multiple collisions. This delay also allows
 	 * the sink device to request power role swap
-	 * and allow the the accept message to be sent
+	 * and allow the accept message to be sent
 	 * prior to CMD_DISCOVER_IDENT being sent in the
 	 * SRC_READY state.
 	 *

--- a/driver/fingerprint/fpc/libfp/fpc_private.c
+++ b/driver/fingerprint/fpc/libfp/fpc_private.c
@@ -102,7 +102,7 @@ static int fpc_check_hwid(void)
 	uint16_t id;
 	int rc;
 
-	/* Clear previous occurences of relevant |errors| flags. */
+	/* Clear previous occurrences of relevant |errors| flags. */
 	errors &= (~FP_ERROR_SPI_COMM & ~FP_ERROR_BAD_HWID);
 
 	spi_buf[0] = FPC_CMD_HW_ID;

--- a/driver/fingerprint/fpc/libfp/fpc_private.h
+++ b/driver/fingerprint/fpc/libfp/fpc_private.h
@@ -86,7 +86,7 @@ enum fpc_error_code_internal {
 	FPC_ERROR_INTERNAL_41 = 41, /* The oscillator calibration resulted in a too high or low value   */
 	FPC_ERROR_INTERNAL_42 = 42, /* Sensor driver was opened with NULL configuration                 */
 	FPC_ERROR_INTERNAL_43 = 43, /* Sensor driver as opened with NULL hw descriptor                  */
-	FPC_ERROR_INTERNAL_44 = 44, /* Error occured during image drive test                            */
+	FPC_ERROR_INTERNAL_44 = 44, /* Error occurred during image drive test                           */
 };
 
 /* FPC specific initialization function to fill their context */

--- a/driver/ppc/sn5s330.h
+++ b/driver/ppc/sn5s330.h
@@ -130,7 +130,7 @@ enum sn5s330_pp_idx {
  *
  * The ILIM_PP1 bit indicates an overcurrent condition when sourcing on power
  * path 1.  For rising edge registers, this indicates an overcurrent has
- * occured; similarly for falling edge, it means the overcurrent condition is no
+ * occurred; similarly for falling edge, it means the overcurrent condition is no
  * longer present.
  */
 #define SN5S330_ILIM_PP1_MASK BIT(4)

--- a/driver/touchpad_st.c
+++ b/driver/touchpad_st.c
@@ -1587,7 +1587,7 @@ static int st_tp_read_frame(void)
 	};
 
 	/*
-	 * Since usb_packet.frame is already ane uint8_t byte array, we can just
+	 * Since usb_packet.frame is already a uint8_t byte array, we can just
 	 * make it the RX buffer for SPI transaction.
 	 *
 	 * When there is a extra byte, since we know that flags is a one byte

--- a/include/ap_hang_detect.h
+++ b/include/ap_hang_detect.h
@@ -12,7 +12,7 @@
 
 /**
  * If the hang detect timers were started and can be stopped by any host
- * command, stop them.  This is intended to be called by the the host command
+ * command, stop them.  This is intended to be called by the host command
  * module.
  */
 void hang_detect_stop_on_host_command(void);

--- a/include/config.h
+++ b/include/config.h
@@ -1075,7 +1075,7 @@
  * OCPC - One Charger IC Per Type-C
  *
  * Define this if the board may have multiple charger ICs in the system.  The
- * assumption is that that primary charger is index 0 and is the charger IC
+ * assumption is that the primary charger is index 0 and is the charger IC
  * connected to the battery FET.  Additionally, `chgnum` is assumed to be the
  * same as the charge port index.
  */

--- a/include/config.h
+++ b/include/config.h
@@ -3149,7 +3149,7 @@
 
 /*
  * Detect power signal interrupt storms, defined as more than
- * CONFIG_POWER_SIGNAL_INTERRUPT_STORM_DETECT_THRESHOLD occurences of a single
+ * CONFIG_POWER_SIGNAL_INTERRUPT_STORM_DETECT_THRESHOLD occurrences of a single
  * power signal interrupt within one second.
  */
 #undef CONFIG_POWER_SIGNAL_INTERRUPT_STORM_DETECT_THRESHOLD

--- a/include/spi_nor.h
+++ b/include/spi_nor.h
@@ -151,7 +151,7 @@ int spi_nor_read(const struct spi_nor_device_t *spi_nor_device,
  * @param spi_nor_device The Serial NOR Flash device to use.
  * @param offset Flash offset to erase, must be aligned to the minimum physical
  *               erase size.
- * @param size Number of Bytes to erase, must be a multiple of the the minimum
+ * @param size Number of Bytes to erase, must be a multiple of the minimum
  *             physical erase size.
  * @return ec_error_list (non-zero on error and timeout).
  */

--- a/include/thermal.h
+++ b/include/thermal.h
@@ -11,7 +11,7 @@
 /* The thermal configuration for a single temp sensor is defined here. */
 #include "ec_commands.h"
 
-/* We need to to hold a config for each board's sensors. Not const, so we can
+/* We need to hold a config for each board's sensors. Not const, so we can
  * tweak it at run-time if we have to.
  */
 extern struct ec_thermal_config thermal_params[];

--- a/include/usb_descriptor.h
+++ b/include/usb_descriptor.h
@@ -55,7 +55,7 @@ struct bos_context {
 struct usb_bos_hdr_descriptor {
 	uint8_t bLength;
 	uint8_t bDescriptorType; /* USB_DT_BOS */
-	uint16_t wTotalLength;   /* Total length of of hdr + all dev caps */
+	uint16_t wTotalLength;   /* Total length of hdr + all dev caps */
 	uint8_t bNumDeviceCaps;  /* Container ID Descriptor + others */
 } __packed;
 #define USB_DT_BOS_SIZE 5

--- a/include/usb_pe_sm.h
+++ b/include/usb_pe_sm.h
@@ -140,7 +140,7 @@ int pd_is_port_partner_dualrole(int port);
 void pe_invalidate_explicit_contract(int port);
 
 /*
- * Return true if the PE is is within an atomic
+ * Return true if the PE is within an atomic
  * messaging sequence that it initiated with a SOP* port partner.
  *
  * Note the PRL layer polls this instead of using AMS_START and AMS_END


### PR DESCRIPTION
Fixes 17 typos found across comments and documentation strings

- `tempurature` → `temperature`
- Duplicate words removed: "the the", "is is", "to to", "and and", "of of", "that that" in include/ and common/ files
- `recieveing` → `receiving`
- `occured` → `occurred`
- `occurences` → `occurrences`
- `ane` → `a`