### PR TITLE
fix battery drain when battery charge threshold is set

### DIFF
--- a/common/charge_state.c
+++ b/common/charge_state.c
@@ -470,8 +470,15 @@ int charge_request(bool use_curr, bool is_full)
 		 */
 		voltage = charger_closest_voltage(
 			curr.batt.voltage + charger_get_info()->voltage_step);
-		/* If the battery is full, request the max voltage. */
-		if (is_full)
+		/*
+		 * If the battery is full, request the max voltage.
+		 *
+		 * Do the same when the sustainer is deliberately holding the
+		 * battery at a charge limit. The intent in
+		 * IDLE is the same as when full: hold, don't charge, and don't
+		 * let the battery back-feed the system.
+		 */
+		if (is_full || get_chg_ctrl_mode() == CHARGE_CONTROL_IDLE)
 			voltage = battery_get_info()->voltage_max;
 		/* And handle dead battery case */
 		voltage = MAX(voltage, battery_get_info()->voltage_normal);


### PR DESCRIPTION
When the battery sustainer parks the pack at a charge limit it enters `CHARGE_CONTROL_IDLE`, which sets manual current and voltage to 0. `charge_request()` then takes the `!voltage || !current` path and, on NVDC chargers, requests `VBAT + one voltage_step`. Per the comment on that branch, the margin exists so that "the BGATE FET body diode" does not "conduct and discharge the battery".

However one voltage_step does not appear to be enough margin: if the rail sags below VBAT under load the diode conducts and the pack supplies part of the system current. Charge current is pinned at 0 in IDLE, so it is never replenished, SoC falls until it crosses the sustainer's lower threshold and triggers a full recharge.

This is what I observe: a shallow charge/discharge between min/max charge threshold. The EC automatically sets `max-5` as the min. When I set the charge threshold to 60%, it charges to 60%, then goes to IDLE (observed in ec console) but then as soon as there is some load on the system, it starts drawing a constant 5-9W from the battery. Until it gets to 55% and charges back up to 60%.

### Stock EC, Min=55%, Max=60% 
- Note it stayed parked for some time, but then suddenly started draining at a constant rate
<img width="1560" height="900" alt="image" src="https://github.com/user-attachments/assets/eafb5ee7-19d9-4372-8932-2934b30984b6" />

### Stock EC, Min=Max=60% 
- Ignore the first couple of charge/discharges, I was testing something.
- Notice how much more it stayed parked, going below 60% switches to Normal mode and replenishes the diode
<img width="1560" height="900" alt="image" src="https://github.com/user-attachments/assets/0342bdf5-4b47-451a-8779-032075d1736e" />


### Patched EC, Min=55%, Max=60%
<img width="1560" height="900" alt="image" src="https://github.com/user-attachments/assets/eb8bed41-dda4-4678-87e5-208095e07702" />


This patch potentially applies to other boards too.

My framework forum post: https://community.frame.work/t/puzzling-battery-threshold-behavior/83941


EDIT: looks like this was found before: [here](https://community.frame.work/t/tracking-battery-flipping-between-charging-and-discharging-draws-from-battery-even-on-ac/22484/489?u=hojjat_abdollahi).